### PR TITLE
Download links

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+REACT_APP_PLAY_STORE_URL=https://play.google.com/apps/testing/org.sagebionetworks.research.mindkind
+REACT_APP_DEEPLINK_URL=https://sagebionetworks.org/Mindkind/sage-mindkind/auth/

--- a/src/components/dashboard/DownloadApp.tsx
+++ b/src/components/dashboard/DownloadApp.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { ReactComponent as LogoNoText } from '../../assets/logo-no-text.svg'
+import { useSessionDataState } from '../../AuthContext'
 
 function DownloadApp() {
+  const { token } = useSessionDataState()
+  const playStoreLink = process.env.REACT_APP_DOWNLOAD_APP_URL
+  const deepLink = `${process.env.REACT_APP_DEEPLINK_URL}${token}`
   return (
     <div className="download-app">
       <div className="download--not-installed">
@@ -11,12 +15,26 @@ function DownloadApp() {
         <p>
           Some placeholder text about the app and what you may do in the app.
         </p>
-        <button className="download__button">Download the app</button>
+        <a
+          className="download__button"
+          href={playStoreLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Download the app
+        </a>
       </div>
       <div className="download--already-installed">
         <h1 className="download__title">If you already have the app</h1>
         <p>Click here to log-in to the app and begin the study!</p>
-        <button className="download__button">Sign In to the App</button>
+        <a
+          className="download__button"
+          href={deepLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Sign In to the App
+        </a>
       </div>
       <div className="phone"></div>
     </div>

--- a/src/components/dashboard/armFlows/ArmFlowThree.tsx
+++ b/src/components/dashboard/armFlows/ArmFlowThree.tsx
@@ -21,8 +21,8 @@ function ArmFlowThree({
   const { t } = useTranslation()
   return (
     <ResponsiveStepWrapper>
+      <ProgressBar step={step} maxSteps={maxSteps} />
       <div className="text-step-wrapper">
-        <ProgressBar step={step} maxSteps={maxSteps} />
         <Globe />
         <div className="header-wrapper">
           <h1>{t('form.armThree.title')}</h1>

--- a/src/styles/components/_download-app.scss
+++ b/src/styles/components/_download-app.scss
@@ -1,7 +1,7 @@
 .download-app {
   .download__button {
     width: 270px;
-    padding: 15px;
+    padding: 10px;
     display: block;
     margin: 36px auto;
     border: none;
@@ -11,6 +11,7 @@
     font-family: 'Lato';
     color: #ffffff;
     cursor: pointer;
+    text-align: center;
   }
   .download--not-installed {
     background-color: #343f56;


### PR DESCRIPTION
What does this PR do?

- Adds links to the download page buttons to redirect to play store if app is not installed or the deeplink if the app is already installed.

- Fixes an issue on the armflow 3 where the progress bar was inside the card wrapper and should be outside to display correctly