### PR TITLE
New pages on Youth Informed

### DIFF
--- a/src/components/dashboard/armFlows/ArmFlowTwo.tsx
+++ b/src/components/dashboard/armFlows/ArmFlowTwo.tsx
@@ -16,6 +16,7 @@ import {
   RESEARCHERS_DATA_USAGE,
 } from 'constants/constants'
 import { ReactComponent as Globe } from 'assets/consent/globe.svg'
+import { createCustomRadio } from 'components/form/CustomRadio'
 import SageForm from 'components/form/SageForm'
 
 type ArmFlowTwoProps = {
@@ -46,102 +47,19 @@ function ArmFlowTwo({
   const [successMessage, setSuccessMessage] = useState('')
   window.scrollTo(0, 0)
 
-  const CustomRadioResearchersDataAccess = ({
-    options,
-    value,
-    onChange,
-  }: any) => {
-    const { enumOptions } = options
-    const _onChange = (event: any) => onChange(event.currentTarget.id)
-    return enumOptions.map((option: any, index: number) => {
-      return (
-        <div
-          className={
-            'quiz-radio-wrapper ' +
-            (option.value ===
-            RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA
-              ? 'radio correct'
-              : '')
-          }
-          key={`quiz-radio-wrapper-${index}`}
-        >
-          <input
-            type="radio"
-            id={option.value}
-            checked={
-              option.value === researchersDataAccessSelection ||
-              option.value ===
-                RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA
-                ? true
-                : false
-            }
-            onChange={_onChange as any}
-          />
-          <div
-            id={`label-${option.value}`}
-            dangerouslySetInnerHTML={{ __html: option.label }}
-            className={
-              'radio-button-label' +
-              (option.value === researchersDataAccessSelection &&
-              option.value !==
-                RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA
-                ? ' error-message wrong-opt'
-                : ' correct-opt')
-            }
-          />
-        </div>
-      )
-    })
-  }
+  const CustomRadioResearchersDataAccess = createCustomRadio(
+    RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA,
+    researchersDataAccessSelection,
+  )
 
   const widgetsResearchersDataAccess = {
     RadioWidget: CustomRadioResearchersDataAccess,
   }
 
-  const CustomRadioResearchersDataUsage = ({
-    options,
-    value,
-    onChange,
-  }: any) => {
-    const { enumOptions } = options
-    const _onChange = (event: any) => onChange(event.currentTarget.id)
-    return enumOptions.map((option: any, index: number) => {
-      return (
-        <div
-          className={
-            'quiz-radio-wrapper ' +
-            (option.value === RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE
-              ? 'radio correct'
-              : '')
-          }
-          key={`quiz-radio-wrapper-${index}`}
-        >
-          <input
-            type="radio"
-            id={option.value}
-            checked={
-              option.value === researchersDataUsageSelection ||
-              option.value === RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE
-                ? true
-                : false
-            }
-            onChange={_onChange as any}
-          />
-          <div
-            id={`label-${option.value}`}
-            dangerouslySetInnerHTML={{ __html: option.label }}
-            className={
-              'radio-button-label' +
-              (option.value === researchersDataUsageSelection &&
-              option.value !== RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE
-                ? ' error-message wrong-opt'
-                : ' correct-opt')
-            }
-          />
-        </div>
-      )
-    })
-  }
+  const CustomRadioResearchersDataUsage = createCustomRadio(
+    RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE,
+    researchersDataUsageSelection,
+  )
 
   const widgetsResearchersDataUsage = {
     RadioWidget: CustomRadioResearchersDataUsage,

--- a/src/components/dashboard/armFlows/ArmFlowTwo.tsx
+++ b/src/components/dashboard/armFlows/ArmFlowTwo.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Typography } from '@material-ui/core'
 import { useTranslation } from 'react-i18next'
 import {
@@ -6,8 +6,17 @@ import {
   ProgressBar,
   ResponsiveStepWrapper,
 } from 'components/common'
-import { PAGE_ID, PAGE_ID_FIELD_NAME } from 'constants/constants'
+import {
+  FORM_IDS,
+  RESEARCHERS_DATA_ACCESS_OPTIONS,
+} from 'components/form/types'
+import {
+  PAGE_ID,
+  PAGE_ID_FIELD_NAME,
+  RESEARCHERS_DATA_USAGE,
+} from 'constants/constants'
 import { ReactComponent as Globe } from 'assets/consent/globe.svg'
+import SageForm from 'components/form/SageForm'
 
 type ArmFlowTwoProps = {
   step: number
@@ -29,7 +38,119 @@ function ArmFlowTwo({
   RankedChoice,
 }: ArmFlowTwoProps) {
   const { t } = useTranslation()
+  const [researchersDataAccessSelection, setResearchersDataAccessSelection] =
+    useState('')
+  const [researchersDataUsageSelection, setResearchersDataUsageSelection] =
+    useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+  const [successMessage, setSuccessMessage] = useState('')
   window.scrollTo(0, 0)
+
+  const CustomRadioResearchersDataAccess = ({
+    options,
+    value,
+    onChange,
+  }: any) => {
+    const { enumOptions } = options
+    const _onChange = (event: any) => onChange(event.currentTarget.id)
+    return enumOptions.map((option: any, index: number) => {
+      return (
+        <div
+          className={
+            'quiz-radio-wrapper ' +
+            (option.value ===
+            RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA
+              ? 'radio correct'
+              : '')
+          }
+          key={`quiz-radio-wrapper-${index}`}
+        >
+          <input
+            type="radio"
+            id={option.value}
+            checked={
+              option.value === researchersDataAccessSelection ||
+              option.value ===
+                RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA
+                ? true
+                : false
+            }
+            onChange={_onChange as any}
+          />
+          <div
+            id={`label-${option.value}`}
+            dangerouslySetInnerHTML={{ __html: option.label }}
+            className={
+              'radio-button-label' +
+              (option.value === researchersDataAccessSelection &&
+              option.value !==
+                RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA
+                ? ' error-message wrong-opt'
+                : ' correct-opt')
+            }
+          />
+        </div>
+      )
+    })
+  }
+
+  const widgetsResearchersDataAccess = {
+    RadioWidget: CustomRadioResearchersDataAccess,
+  }
+
+  const CustomRadioResearchersDataUsage = ({
+    options,
+    value,
+    onChange,
+  }: any) => {
+    const { enumOptions } = options
+    const _onChange = (event: any) => onChange(event.currentTarget.id)
+    return enumOptions.map((option: any, index: number) => {
+      return (
+        <div
+          className={
+            'quiz-radio-wrapper ' +
+            (option.value === RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE
+              ? 'radio correct'
+              : '')
+          }
+          key={`quiz-radio-wrapper-${index}`}
+        >
+          <input
+            type="radio"
+            id={option.value}
+            checked={
+              option.value === researchersDataUsageSelection ||
+              option.value === RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE
+                ? true
+                : false
+            }
+            onChange={_onChange as any}
+          />
+          <div
+            id={`label-${option.value}`}
+            dangerouslySetInnerHTML={{ __html: option.label }}
+            className={
+              'radio-button-label' +
+              (option.value === researchersDataUsageSelection &&
+              option.value !== RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE
+                ? ' error-message wrong-opt'
+                : ' correct-opt')
+            }
+          />
+        </div>
+      )
+    })
+  }
+
+  const widgetsResearchersDataUsage = {
+    RadioWidget: CustomRadioResearchersDataUsage,
+  }
+
+  useEffect(() => {
+    setErrorMessage('')
+    setSuccessMessage('')
+  }, [step])
 
   switch (step) {
     case 1:
@@ -55,7 +176,7 @@ function ArmFlowTwo({
               onBack={handleBack}
               onNext={() =>
                 handleNext({
-                  [PAGE_ID_FIELD_NAME]: PAGE_ID.VOTING_01,
+                  [PAGE_ID_FIELD_NAME]: PAGE_ID.YOUTH_INFORMED_01,
                 })
               }
             />
@@ -64,11 +185,110 @@ function ArmFlowTwo({
       )
 
     case 2:
+      return (
+        <ResponsiveStepWrapper variant="card">
+          <ProgressBar step={step} maxSteps={maxSteps} />
+          <div className="quiz-wrapper">
+            <SageForm
+              title={t('form.armOne.pageOne.title')}
+              errorMessage={errorMessage}
+              infoMessage={successMessage}
+              formId={FORM_IDS.RESEARCHERS_DATA_ACCESS}
+              widgets={
+                researchersDataAccessSelection
+                  ? widgetsResearchersDataAccess
+                  : undefined
+              }
+              onSubmit={(event: any) => {
+                const selectedOption = event.formData.researchersDataAccess
+                if (
+                  selectedOption === undefined &&
+                  researchersDataAccessSelection === ''
+                ) {
+                  setErrorMessage(t('form.chooseAnOption'))
+                  setSuccessMessage('')
+                } else {
+                  if (
+                    selectedOption ===
+                    RESEARCHERS_DATA_ACCESS_OPTIONS.WILL_ONLY_VIEW_DATA
+                  ) {
+                    setSuccessMessage(t('form.armTwo.pageTwo.correctAnswer'))
+                    setErrorMessage('')
+                  } else {
+                    setErrorMessage(t('form.armTwo.pageTwo.incorrectAnswer'))
+                    setSuccessMessage('')
+                  }
+                  if (successMessage || researchersDataAccessSelection) {
+                    handleNext()
+                  } else {
+                    setResearchersDataAccessSelection(selectedOption)
+                    updateClientData({
+                      [FORM_IDS.RESEARCHERS_DATA_ACCESS]: selectedOption,
+                      [PAGE_ID_FIELD_NAME]: PAGE_ID.YOUTH_INFORMED_02,
+                    })
+                  }
+                }
+              }}
+            />
+          </div>
+        </ResponsiveStepWrapper>
+      )
+
     case 3:
+      return (
+        <ResponsiveStepWrapper variant="card">
+          <ProgressBar step={step} maxSteps={maxSteps} />
+          <div className="quiz-wrapper">
+            <SageForm
+              title={t('form.armTwo.pageThree.title')}
+              errorMessage={errorMessage}
+              infoMessage={successMessage}
+              formId={FORM_IDS.RESEARCHERS_DATA_USAGE}
+              widgets={
+                researchersDataUsageSelection
+                  ? widgetsResearchersDataUsage
+                  : undefined
+              }
+              onSubmit={(event: any) => {
+                const selectedOption = event.formData.researchersDataUsage
+                if (
+                  selectedOption === undefined &&
+                  researchersDataUsageSelection === ''
+                ) {
+                  setErrorMessage(t('form.chooseAnOption'))
+                  setSuccessMessage('')
+                } else {
+                  if (
+                    selectedOption ===
+                    RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE
+                  ) {
+                    setSuccessMessage(t('form.armTwo.pageThree.correctAnswer'))
+                    setErrorMessage('')
+                  } else {
+                    setErrorMessage(t('form.armTwo.pageThree.incorrectAnswer'))
+                    setSuccessMessage('')
+                  }
+                  if (successMessage || researchersDataUsageSelection) {
+                    handleNext()
+                  } else {
+                    setResearchersDataUsageSelection(selectedOption)
+                    updateClientData({
+                      [FORM_IDS.DATA_RESEARCH_TYPE]: selectedOption,
+                      [PAGE_ID_FIELD_NAME]: PAGE_ID.YOUTH_INFORMED_03,
+                    })
+                  }
+                }
+              }}
+            />
+          </div>
+        </ResponsiveStepWrapper>
+      )
     case 4:
     case 5:
     case 6:
     case 7:
+    case 8:
+    case 9:
       return (
         <RankedChoice
           step={step}
@@ -77,7 +297,7 @@ function ArmFlowTwo({
           handleBack={handleBack}
           handleNext={handleNext}
           handleComplete={handleComplete}
-          startingStep={2}
+          startingStep={4}
         />
       )
 

--- a/src/components/form/SageForm.tsx
+++ b/src/components/form/SageForm.tsx
@@ -82,6 +82,11 @@ import {
   uiSchemaDataSharing,
 } from '../../data/schemas/dataSharing'
 
+import {
+  schemaResearchersDataUsage,
+  uiSchemaResearchersDataUsage,
+} from '../../data/schemas/researchersDataUsage'
+
 import { schemaGender, uiSchemaGender } from '../../data/schemas/gender'
 import { cloneDeep, shuffle } from 'lodash'
 import { useTranslation } from 'react-i18next'
@@ -180,6 +185,8 @@ export default function SageForm({
         return schemaDataUsage
       case FORM_IDS.DATA_SHARING:
         return schemaDataSharing
+      case FORM_IDS.RESEARCHERS_DATA_USAGE:
+        return schemaResearchersDataUsage
       default:
         return null
     }
@@ -223,6 +230,8 @@ export default function SageForm({
         return uiSchemaDataUsage
       case FORM_IDS.DATA_SHARING:
         return uiSchemaDataSharing
+      case FORM_IDS.RESEARCHERS_DATA_USAGE:
+        return uiSchemaResearchersDataUsage
       default:
         return null
     }

--- a/src/components/form/types.js
+++ b/src/components/form/types.js
@@ -55,4 +55,5 @@ export const FORM_IDS = {
   DATA_PAYMENT: 'dataPayment',
   DATA_USAGE: 'dataUsage',
   DATA_SHARING: 'dataSharing',
+  RESEARCHERS_DATA_USAGE: 'researchersDataUsage',
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -118,6 +118,13 @@ export const DATA_RESEARCH_TYPE = {
     'All kinds of research, including commercial (for profit) research.',
 }
 
+export const RESEARCHERS_DATA_USAGE = {
+  RESEARCHERS_WILL_DECIDE: 'Researchers will decide how study data is used.',
+  STUDY_PARTICIPANTS_DECIDE:
+    'Study participants vote to decide how study data is used.',
+  GOVERMENT_DECIDE: 'The government will decide how study data is used.',
+}
+
 export const COUNTRY_CODES = {
   UK: 'UK',
   IN: 'IN',

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -148,7 +148,16 @@
       "title": "How will your study data be used?",
       "subTitle": "You and other participants get to vote how researchers can access and use your data.",
       "subText1": "Researchers will only view your data on a secure server - they cannot download your data.",
-      "subText2": "Before researchers can use the data, we will tell you the voting results."
+      "subText2": "Before researchers can use the data, we will tell you the voting results.",
+      "pageTwo": {
+        "correctAnswer": "Correct! Researchers will only view your data on a secure server. They cannot download your data.",
+        "incorrectAnswer": "Researchers will only view your data on a secure server. They cannot download your data."
+      },
+      "pageThree": {
+        "title": "How will researchers use your data?",
+        "correctAnswer": "Correct! Study participants vote to decide how study data is used.",
+        "incorrectAnswer": "Study participants vote to decide how study data is used."
+      }
     },
     "armThree": {
       "title": "How will your study data be used?",

--- a/src/data/schemas/researchersDataUsage.js
+++ b/src/data/schemas/researchersDataUsage.js
@@ -1,0 +1,23 @@
+import { RESEARCHERS_DATA_USAGE } from '../../constants/constants'
+
+export const schemaResearchersDataUsage = {
+  type: 'object',
+  properties: {
+    researchersDataUsage: {
+      type: 'string',
+      title: ' ',
+      enum: [
+        RESEARCHERS_DATA_USAGE.RESEARCHERS_WILL_DECIDE,
+        RESEARCHERS_DATA_USAGE.STUDY_PARTICIPANTS_DECIDE,
+        RESEARCHERS_DATA_USAGE.GOVERMENT_DECIDE,
+      ],
+      uniqueItems: true,
+    },
+  },
+}
+
+export const uiSchemaResearchersDataUsage = {
+  researchersDataUsage: {
+    'ui:widget': 'radio',
+  },
+}


### PR DESCRIPTION
<img width="306" alt="Screen Shot 2021-07-08 at 23 22 11" src="https://user-images.githubusercontent.com/26776103/125027666-d66f9680-e043-11eb-810d-896a0ea9d992.png">
<img width="307" alt="Screen Shot 2021-07-08 at 23 22 19" src="https://user-images.githubusercontent.com/26776103/125027676-d8d1f080-e043-11eb-8427-3ae1d7aee39d.png">
<img width="299" alt="Screen Shot 2021-07-08 at 23 22 28" src="https://user-images.githubusercontent.com/26776103/125027681-db344a80-e043-11eb-86a5-02fcf6cdbeb1.png">
<img width="305" alt="Screen Shot 2021-07-08 at 23 22 37" src="https://user-images.githubusercontent.com/26776103/125027685-dd96a480-e043-11eb-9be8-a3697adc9b99.png">
<img width="307" alt="Screen Shot 2021-07-08 at 23 21 41" src="https://user-images.githubusercontent.com/26776103/125027690-dff8fe80-e043-11eb-8672-481ab9f6cfd0.png">
<img width="295" alt="Screen Shot 2021-07-08 at 23 21 52" src="https://user-images.githubusercontent.com/26776103/125027698-e25b5880-e043-11eb-89f1-00c3607e6e79.png">
<img width="292" alt="Screen Shot 2021-07-08 at 23 22 05" src="https://user-images.githubusercontent.com/26776103/125027708-e4bdb280-e043-11eb-9063-9a5462cf15b3.png">

## Added
- ResearchersDataUsage schema for new Quiz
- Added Steps on ArmFlow two.
- Added ResearchersDataUsage constants

## Modified
- Modified SageForm to render ReseachersDataUsage